### PR TITLE
Fix faulty header guard

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -29,7 +29,7 @@ class OpenSpliceConan(ConanFile):
     _find_script = "FindOpenSplice.cmake"
     _source_subfolder = "source_subfolder"
 
-    exports_sources = [_build_script, _find_script]
+    exports_sources = [_build_script, _find_script, "patches/*"]
 
     @property
     def _ospl_platform(self):
@@ -109,6 +109,8 @@ class OpenSpliceConan(ConanFile):
                                  'setup',
                                  'configuration',
                                  'setup_x86_64.linux_clang'))
+        # patch xtypes errors (remove if this gets fixed...)
+        tools.patch(patch_file=os.path.join('patches','TypeKind.hpp.patch'), base_path=self._source_subfolder)
 
     def build(self):
         config = "dev" if self.settings.build_type == "Debug" else "release"

--- a/patches/TypeKind.hpp.patch
+++ b/patches/TypeKind.hpp.patch
@@ -1,0 +1,16 @@
+--- src/api/dcps/isocpp2/include/dds/core/xtypes/TypeKind.hpp	2020-11-24 16:03:33.223558641 +0100
++++ src/api/dcps/isocpp2/include/dds/core/xtypes/TypeKind.hpp	2020-11-24 16:04:57.267558641 +0100
+@@ -1,5 +1,5 @@
+-#ifndef OMG_DDS_XTYPE_
+-#define OMG_DDS_TYPE_OBJECT_HPP_
++#ifndef OMG_DDS_XTYPE_TYPEKIND_HPP_
++#define OMG_DDS_XTYPE_TYPEKIND_HPP_
+ 
+ /* Copyright 2010, Object Management Group, Inc.
+  * Copyright 2010, PrismTech, Corp.
+@@ -85,4 +85,4 @@
+ #endif  // OMG_DDS_X_TYPES_DYNANIC_TYPE_SUPPORT
+ 
+ 
+-#endif // !defined(OMG_DDS_TYPE_OBJECT_HPP_)
++#endif // !defined(OMG_DDS_XTYPE_TYPEKIND_HPP_)


### PR DESCRIPTION
The header guard in TypeKind.hpp is wrong. This applies a patch to fix it.

This is needed to fix DAQA-111