### PR TITLE
Fix build script permissions, update build matrix

### DIFF
--- a/.github/workflows/ci-conan-gcc.yml
+++ b/.github/workflows/ci-conan-gcc.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         conan: ["2.0"]
         profile: [gcc]
-        compiler_version: [8, 9, 10, 11, 12, 13]
+        compiler_version: [8, 9, 10, 11, 12]
         build_type: [Debug, Release]
         version: ["6.9.210323"]
         channel: ["${{ (github.head_ref || github.ref_name) == 'master' && 'stable' || 'testing' }}"]

--- a/.github/workflows/ci-conan-gcc.yml
+++ b/.github/workflows/ci-conan-gcc.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        conan: ["1.0", "2.0"]
+        conan: ["2.0"]
         profile: [gcc]
-        compiler_version: [8, 9, 10, 11, 12]
+        compiler_version: [8, 9, 10, 11, 12, 13]
         build_type: [Debug, Release]
         version: ["6.9.210323"]
         channel: ["${{ (github.head_ref || github.ref_name) == 'master' && 'stable' || 'testing' }}"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -67,7 +67,6 @@ class OpenSpliceConan(ConanFile):
         copy(self, '*', join(self.recipe_folder, "patches"), join(self.export_sources_folder, "patches"))
         copy(self, '*', join(self.recipe_folder, "setup"), join(self.export_sources_folder, "setup"))
         copy(self, self._build_script, self.recipe_folder, self.export_sources_folder)
-        os.chmod(join(self.export_sources_folder, self._build_script), 0o755)
         copy(self, "OpenSpliceHelpers.cmake", self.recipe_folder, self.export_sources_folder)
 
     def config_options(self):
@@ -170,6 +169,8 @@ class OpenSpliceConan(ConanFile):
         source = self.source_folder
         if self.settings.os == "Windows":
             source = str(source).replace('\\', '/')
+        else:
+            os.chmod(join(self.export_sources_folder, self._build_script), 0o755)
         msvc = "msvc" if is_msvc(self) else ""
 
         self.run(f"./{self._build_script} {source} {self._ospl_platform}-{config} {jobs} {msvc}", cwd=self.export_sources_folder)


### PR DESCRIPTION
The executable bit on `build-opensplice.sh` apparently doesn't survive Conan's source packaging. Therefore, I've moved the `chmod` operation from `export_sources()` to `build()`.

At @joakimono's request, I've also ~~added GCC 13 and~~ removed Conan 1.x from the CI build matrix.

**Edit:** Apparently, a `conanio/gcc13-ubuntu18.04` image doesn't exist yet.